### PR TITLE
index.html: fix './src/HappUiDragme.js'

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
   <script type="module">
     import './src/HappSheet.js';
-    import './src/happUiDragme.js';
+    import './src/HappUiDragme.js';
   </script>
 </body>
 </html>


### PR DESCRIPTION
(from './src/happUiDragme.js' - OSX uses case-insensitive filenames)